### PR TITLE
Fix saving behavior for WPF SettingsView options

### DIFF
--- a/StarResonanceDpsAnalysis.WPF/Config/AppConfig.cs
+++ b/StarResonanceDpsAnalysis.WPF/Config/AppConfig.cs
@@ -52,19 +52,19 @@ public partial class AppConfig : ObservableObject
     /// 战斗计时清除延迟（秒）
     /// </summary>
     [ObservableProperty]
-    private int _combatTimeClearDelay;
+    private int _combatTimeClearDelay = 5;
 
     /// <summary>
     /// 是否过图清空全程记录
     /// </summary>
     [ObservableProperty]
-    private int _clearLogAfterTeleport;
+    private bool _clearLogAfterTeleport;
 
     /// <summary>
     /// 不透明度（0-100）, 默认100, 0为全透明
     /// </summary>
     [ObservableProperty]
-    private double _opacity;
+    private double _opacity = 100;
 
     /// <summary>
     /// 是否使用浅色模式

--- a/StarResonanceDpsAnalysis.WPF/ViewModels/SettingsViewModel.cs
+++ b/StarResonanceDpsAnalysis.WPF/ViewModels/SettingsViewModel.cs
@@ -129,15 +129,15 @@ public partial class SettingsViewModel(IConfigManager configManger, IDeviceManag
         }
     }
 
-    public void ApplySettings()
+    public Task ApplySettingsAsync()
     {
-        configManger.SaveAsync(AppConfig);
+        return configManger.SaveAsync(AppConfig);
     }
 
     [RelayCommand]
-    private void Confirm()
+    private async Task Confirm()
     {
-        ApplySettings();
+        await ApplySettingsAsync();
         RequestClose?.Invoke();
     }
 

--- a/StarResonanceDpsAnalysis.WPF/Views/SettingsView.xaml
+++ b/StarResonanceDpsAnalysis.WPF/Views/SettingsView.xaml
@@ -118,8 +118,7 @@
                                     Grid.Column="1"
                                     DisplayMemberPath="Description"
                                     ItemsSource="{Binding AvailableNetworkAdapters, UpdateSourceTrigger=PropertyChanged}"
-                                    SelectedIndex="0"
-                                    SelectedItem="{Binding AppConfig.PreferredNetworkAdapter}"
+                                    SelectedItem="{Binding AppConfig.PreferredNetworkAdapter, Mode=TwoWay}"
                                     SelectedValuePath="Description"
                                     Style="{StaticResource AntComboBoxStyle}" />
                             </Grid>
@@ -229,7 +228,8 @@
                                         Margin="2"
                                         HorizontalContentAlignment="Center"
                                         VerticalContentAlignment="Center"
-                                        Style="{StaticResource AntTextBoxStyle}" />
+                                        Style="{StaticResource AntTextBoxStyle}"
+                                        Text="{Binding AppConfig.CombatTimeClearDelay, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                     <TextBlock Grid.Column="2">秒</TextBlock>
                                 </Grid>
                                 <TextBlock Grid.Row="1" Grid.Column="0">
@@ -239,7 +239,8 @@
                                     Grid.Row="1"
                                     Grid.Column="1"
                                     OffContent="Off"
-                                    OnContent="On" />
+                                    OnContent="On"
+                                    IsChecked="{Binding AppConfig.ClearLogAfterTeleport, Mode=TwoWay}" />
                                 <TextBlock Grid.Row="2" Grid.Column="0">
                                     计数显示类型
                                 </TextBlock>
@@ -249,8 +250,7 @@
                                     Grid.Column="1"
                                     Margin="2"
                                     ItemsSource="{Binding AvailableNumberDisplayModes}"
-                                    SelectedIndex="0"
-                                    SelectedItem="{Binding AppConfig.DamageDisplayType}"
+                                    SelectedItem="{Binding AppConfig.DamageDisplayType, Mode=TwoWay}"
                                     Style="{StaticResource AntComboBoxStyle}" />
                                 <TextBlock Grid.Row="3" Grid.Column="0">
                                     窗体透明度
@@ -259,7 +259,12 @@
                                     Grid.Row="3"
                                     Grid.Column="1"
                                     VerticalAlignment="Center"
-                                    Style="{StaticResource AntSliderStyle}" />
+                                    Maximum="100"
+                                    Minimum="0"
+                                    Style="{StaticResource AntSliderStyle}"
+                                    TickFrequency="1"
+                                    IsSnapToTickEnabled="True"
+                                    Value="{Binding AppConfig.Opacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             </Grid>
                         </ctrl:CardControl.Content>
                     </ctrl:CardControl>


### PR DESCRIPTION
## Summary
- bind the SettingsView controls to AppConfig so selected values persist for adapters, combat timer, teleport clearing, number display mode, and opacity
- set sensible defaults in AppConfig and use a boolean for the teleport clearing toggle
- await configuration persistence before closing the settings dialog

## Testing
- dotnet build StarResonanceDpsAnalysis.sln *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db5bf1fff88325866eaf85b8cf4ee0